### PR TITLE
feat: `setClaimRecipient`

### DIFF
--- a/src/interfaces/IWrappedMToken.sol
+++ b/src/interfaces/IWrappedMToken.sol
@@ -22,6 +22,13 @@ interface IWrappedMToken is IMigratable, IERC20Extended {
     event Claimed(address indexed account, address indexed recipient, uint240 yield);
 
     /**
+     * @notice Emitted when `account` set their yield claim recipient.
+     * @param  account        The account that set their yield claim recipient.
+     * @param  claimRecipient The account that will receive the yield.
+     */
+    event ClaimRecipientSet(address indexed account, address indexed claimRecipient);
+
+    /**
      * @notice Emitted when earning is enabled for the entire wrapper.
      * @param  index The index at the moment earning is enabled.
      */
@@ -84,6 +91,9 @@ interface IWrappedMToken is IMigratable, IERC20Extended {
 
     /// @notice Emitted when the non-governance migrate function is called by a account other than the migration admin.
     error UnauthorizedMigration();
+
+    /// @notice Emitted in an account is 0x0.
+    error ZeroAccount();
 
     /// @notice Emitted in constructor if Earner Manager is 0x0.
     error ZeroEarnerManager();
@@ -209,6 +219,12 @@ interface IWrappedMToken is IMigratable, IERC20Extended {
      */
     function stopEarningFor(address[] calldata accounts) external;
 
+    /**
+     * @notice Explicitly sets the recipient of any yield claimed for the caller.
+     * @param  claimRecipient The account that will receive the caller's yield.
+     */
+    function setClaimRecipient(address claimRecipient) external;
+
     /* ============ Temporary Admin Migration ============ */
 
     /**
@@ -260,7 +276,7 @@ interface IWrappedMToken is IMigratable, IERC20Extended {
      * @param  account   The account being queried.
      * @return recipient The address of the recipient, if any, to override as the destination of claimed yield.
      */
-    function claimOverrideRecipientFor(address account) external view returns (address recipient);
+    function claimRecipientFor(address account) external view returns (address recipient);
 
     /// @notice The current index of the wrapper's earning mechanism.
     function currentIndex() external view returns (uint128 index);

--- a/test/integration/MorphoBlue.t.sol
+++ b/test/integration/MorphoBlue.t.sol
@@ -299,7 +299,7 @@ contract MorphoBlueTests is MorphoTestBase {
         // Check that the pool is earning wM.
         assertTrue(_wrappedMToken.isEarning(_MORPHO));
 
-        assertEq(_wrappedMToken.claimOverrideRecipientFor(_MORPHO), _carol);
+        assertEq(_wrappedMToken.claimRecipientFor(_MORPHO), _carol);
 
         assertEq(_wrappedMToken.balanceOf(_MORPHO), _morphoBalanceOfWM);
         assertEq(_wrappedMToken.accruedYieldOf(_MORPHO), _morphoAccruedYield);
@@ -418,7 +418,7 @@ contract MorphoBlueTests is MorphoTestBase {
         // Check that the pool is earning wM.
         assertTrue(_wrappedMToken.isEarning(_MORPHO));
 
-        assertEq(_wrappedMToken.claimOverrideRecipientFor(_MORPHO), _carol);
+        assertEq(_wrappedMToken.claimRecipientFor(_MORPHO), _carol);
 
         assertEq(_wrappedMToken.balanceOf(_MORPHO), _morphoBalanceOfWM);
         assertEq(_wrappedMToken.accruedYieldOf(_MORPHO), _morphoAccruedYield);

--- a/test/integration/UniswapV3.t.sol
+++ b/test/integration/UniswapV3.t.sol
@@ -138,7 +138,7 @@ contract UniswapV3IntegrationTests is TestBase {
 
         assertTrue(_wrappedMToken.isEarning(_pool));
 
-        assertEq(_wrappedMToken.claimOverrideRecipientFor(_pool), _carol);
+        assertEq(_wrappedMToken.claimRecipientFor(_pool), _carol);
 
         assertEq(_wrappedMToken.balanceOf(_pool), _poolBalanceOfWM);
         assertEq(_wrappedMToken.accruedYieldOf(_pool), _poolAccruedYield);
@@ -249,7 +249,7 @@ contract UniswapV3IntegrationTests is TestBase {
         // Check that the pool is earning WM
         assertTrue(_wrappedMToken.isEarning(_pool));
 
-        assertEq(_wrappedMToken.claimOverrideRecipientFor(_pool), _carol);
+        assertEq(_wrappedMToken.claimRecipientFor(_pool), _carol);
 
         assertEq(_wrappedMToken.balanceOf(_pool), _poolBalanceOfWM);
         assertEq(_wrappedMToken.accruedYieldOf(_pool), _poolAccruedYield);
@@ -357,7 +357,7 @@ contract UniswapV3IntegrationTests is TestBase {
 
         assertTrue(_wrappedMToken.isEarning(_pool));
 
-        assertEq(_wrappedMToken.claimOverrideRecipientFor(_pool), _carol);
+        assertEq(_wrappedMToken.claimRecipientFor(_pool), _carol);
 
         /* ============ Alice Mints New LP Position ============ */
 
@@ -484,7 +484,7 @@ contract UniswapV3IntegrationTests is TestBase {
 
         assertTrue(_wrappedMToken.isEarning(_pool));
 
-        assertEq(_wrappedMToken.claimOverrideRecipientFor(_pool), _carol);
+        assertEq(_wrappedMToken.claimRecipientFor(_pool), _carol);
 
         /* ============ Fund Alice (Non-Earner) and Bob (Earner) ============ */
 

--- a/test/unit/WrappedMToken.t.sol
+++ b/test/unit/WrappedMToken.t.sol
@@ -130,7 +130,7 @@ contract WrappedMTokenTests is Test {
     function test_internalWrap_invalidRecipient() external {
         _mToken.setBalanceOf(_alice, 1_000);
 
-        vm.expectRevert(abi.encodeWithSelector(IERC20Extended.InvalidRecipient.selector, address(0)));
+        vm.expectRevert(IWrappedMToken.ZeroAccount.selector);
 
         _wrappedMToken.internalWrap(_alice, address(0), 1_000);
     }
@@ -154,7 +154,7 @@ contract WrappedMTokenTests is Test {
 
         _wrappedMToken.enableEarning();
 
-        _wrappedMToken.setAccountOf(_alice, 0, _EXP_SCALED_ONE, false);
+        _wrappedMToken.setAccountOf(_alice, 0, _EXP_SCALED_ONE, false, false);
 
         _mToken.setBalanceOf(_alice, 1_002);
 
@@ -220,7 +220,7 @@ contract WrappedMTokenTests is Test {
         balance_ = uint240(bound(balance_, 0, _getMaxAmount(accountIndex_)));
 
         if (accountEarning_) {
-            _wrappedMToken.setAccountOf(_alice, balance_, accountIndex_, false);
+            _wrappedMToken.setAccountOf(_alice, balance_, accountIndex_, false, false);
             _wrappedMToken.setTotalEarningSupply(balance_);
 
             _wrappedMToken.setPrincipalOfTotalEarningSupply(
@@ -288,7 +288,7 @@ contract WrappedMTokenTests is Test {
         balance_ = uint240(bound(balance_, 0, _getMaxAmount(accountIndex_)));
 
         if (accountEarning_) {
-            _wrappedMToken.setAccountOf(_alice, balance_, accountIndex_, false);
+            _wrappedMToken.setAccountOf(_alice, balance_, accountIndex_, false, false);
             _wrappedMToken.setTotalEarningSupply(balance_);
 
             _wrappedMToken.setPrincipalOfTotalEarningSupply(
@@ -354,7 +354,7 @@ contract WrappedMTokenTests is Test {
         balance_ = uint240(bound(balance_, 0, _getMaxAmount(accountIndex_)));
 
         if (accountEarning_) {
-            _wrappedMToken.setAccountOf(_alice, balance_, accountIndex_, false);
+            _wrappedMToken.setAccountOf(_alice, balance_, accountIndex_, false, false);
             _wrappedMToken.setTotalEarningSupply(balance_);
 
             _wrappedMToken.setPrincipalOfTotalEarningSupply(
@@ -420,7 +420,7 @@ contract WrappedMTokenTests is Test {
         balance_ = uint240(bound(balance_, 0, _getMaxAmount(accountIndex_)));
 
         if (accountEarning_) {
-            _wrappedMToken.setAccountOf(_alice, balance_, accountIndex_, false);
+            _wrappedMToken.setAccountOf(_alice, balance_, accountIndex_, false, false);
             _wrappedMToken.setTotalEarningSupply(balance_);
 
             _wrappedMToken.setPrincipalOfTotalEarningSupply(
@@ -478,7 +478,7 @@ contract WrappedMTokenTests is Test {
 
         _wrappedMToken.enableEarning();
 
-        _wrappedMToken.setAccountOf(_alice, 999, _currentIndex, false);
+        _wrappedMToken.setAccountOf(_alice, 999, _currentIndex, false, false);
 
         vm.expectRevert(abi.encodeWithSelector(IWrappedMToken.InsufficientBalance.selector, _alice, 999, 1_000));
         _wrappedMToken.internalUnwrap(_alice, _alice, 1_000);
@@ -520,7 +520,7 @@ contract WrappedMTokenTests is Test {
         _wrappedMToken.setPrincipalOfTotalEarningSupply(909);
         _wrappedMToken.setTotalEarningSupply(1_000);
 
-        _wrappedMToken.setAccountOf(_alice, 1_000, _currentIndex, false);
+        _wrappedMToken.setAccountOf(_alice, 1_000, _currentIndex, false, false);
 
         _mToken.setBalanceOf(address(_wrappedMToken), 1_000);
 
@@ -573,7 +573,7 @@ contract WrappedMTokenTests is Test {
         balance_ = uint240(bound(balance_, 0, _getMaxAmount(accountIndex_)));
 
         if (accountEarning_) {
-            _wrappedMToken.setAccountOf(_alice, balance_, accountIndex_, false);
+            _wrappedMToken.setAccountOf(_alice, balance_, accountIndex_, false, false);
             _wrappedMToken.setTotalEarningSupply(balance_);
 
             _wrappedMToken.setPrincipalOfTotalEarningSupply(
@@ -641,7 +641,7 @@ contract WrappedMTokenTests is Test {
         balance_ = uint240(bound(balance_, 0, _getMaxAmount(accountIndex_)));
 
         if (accountEarning_) {
-            _wrappedMToken.setAccountOf(_alice, balance_, accountIndex_, false);
+            _wrappedMToken.setAccountOf(_alice, balance_, accountIndex_, false, false);
             _wrappedMToken.setTotalEarningSupply(balance_);
 
             _wrappedMToken.setPrincipalOfTotalEarningSupply(
@@ -692,7 +692,7 @@ contract WrappedMTokenTests is Test {
 
         _wrappedMToken.enableEarning();
 
-        _wrappedMToken.setAccountOf(_alice, 1_000, _EXP_SCALED_ONE, false);
+        _wrappedMToken.setAccountOf(_alice, 1_000, _EXP_SCALED_ONE, false, false);
 
         assertEq(_wrappedMToken.balanceOf(_alice), 1_000);
 
@@ -717,7 +717,7 @@ contract WrappedMTokenTests is Test {
 
         _wrappedMToken.enableEarning();
 
-        _wrappedMToken.setAccountOf(_alice, 1_000, _EXP_SCALED_ONE, false);
+        _wrappedMToken.setAccountOf(_alice, 1_000, _EXP_SCALED_ONE, false, false);
 
         assertEq(_wrappedMToken.balanceOf(_alice), 1_000);
 
@@ -741,7 +741,7 @@ contract WrappedMTokenTests is Test {
 
         _wrappedMToken.enableEarning();
 
-        _wrappedMToken.setAccountOf(_alice, 1_000, _EXP_SCALED_ONE, true);
+        _wrappedMToken.setAccountOf(_alice, 1_000, _EXP_SCALED_ONE, true, false);
 
         _earnerManager.setEarnerDetails(_alice, true, 1_500, _bob);
 
@@ -767,7 +767,7 @@ contract WrappedMTokenTests is Test {
 
         _wrappedMToken.enableEarning();
 
-        _wrappedMToken.setAccountOf(_alice, 1_000, _EXP_SCALED_ONE, true);
+        _wrappedMToken.setAccountOf(_alice, 1_000, _EXP_SCALED_ONE, true, false);
 
         _earnerManager.setEarnerDetails(_alice, true, type(uint16).max, _bob);
 
@@ -798,7 +798,7 @@ contract WrappedMTokenTests is Test {
 
         _wrappedMToken.enableEarning();
 
-        _wrappedMToken.setAccountOf(_alice, 1_000, _EXP_SCALED_ONE, true);
+        _wrappedMToken.setAccountOf(_alice, 1_000, _EXP_SCALED_ONE, true, false);
 
         _earnerManager.setEarnerDetails(_alice, true, 1_500, _bob);
 
@@ -847,7 +847,7 @@ contract WrappedMTokenTests is Test {
 
         _wrappedMToken.setTotalEarningSupply(balance_);
 
-        _wrappedMToken.setAccountOf(_alice, balance_, accountIndex_, feeRate_ != 0);
+        _wrappedMToken.setAccountOf(_alice, balance_, accountIndex_, feeRate_ != 0, false);
 
         if (feeRate_ != 0) {
             _earnerManager.setEarnerDetails(_alice, true, feeRate_, _bob);
@@ -927,7 +927,7 @@ contract WrappedMTokenTests is Test {
     function test_transfer_invalidRecipient() external {
         _wrappedMToken.setAccountOf(_alice, 1_000);
 
-        vm.expectRevert(abi.encodeWithSelector(IERC20Extended.InvalidRecipient.selector, address(0)));
+        vm.expectRevert(IWrappedMToken.ZeroAccount.selector);
 
         vm.prank(_alice);
         _wrappedMToken.transfer(address(0), 1_000);
@@ -946,7 +946,7 @@ contract WrappedMTokenTests is Test {
 
         _wrappedMToken.enableEarning();
 
-        _wrappedMToken.setAccountOf(_alice, 999, _currentIndex, false);
+        _wrappedMToken.setAccountOf(_alice, 999, _currentIndex, false, false);
 
         vm.expectRevert(abi.encodeWithSelector(IWrappedMToken.InsufficientBalance.selector, _alice, 999, 1_000));
         vm.prank(_alice);
@@ -1013,7 +1013,7 @@ contract WrappedMTokenTests is Test {
 
         _wrappedMToken.setTotalNonEarningSupply(500);
 
-        _wrappedMToken.setAccountOf(_alice, 1_000, _currentIndex, false);
+        _wrappedMToken.setAccountOf(_alice, 1_000, _currentIndex, false, false);
         _wrappedMToken.setAccountOf(_bob, 500);
 
         vm.expectEmit();
@@ -1056,7 +1056,7 @@ contract WrappedMTokenTests is Test {
         _wrappedMToken.setTotalNonEarningSupply(1_000);
 
         _wrappedMToken.setAccountOf(_alice, 1_000);
-        _wrappedMToken.setAccountOf(_bob, 500, _currentIndex, false);
+        _wrappedMToken.setAccountOf(_bob, 500, _currentIndex, false, false);
 
         vm.expectEmit();
         emit IERC20.Transfer(_alice, _bob, 500);
@@ -1081,8 +1081,8 @@ contract WrappedMTokenTests is Test {
         _wrappedMToken.setPrincipalOfTotalEarningSupply(1_363);
         _wrappedMToken.setTotalEarningSupply(1_500);
 
-        _wrappedMToken.setAccountOf(_alice, 1_000, _currentIndex, false);
-        _wrappedMToken.setAccountOf(_bob, 500, _currentIndex, false);
+        _wrappedMToken.setAccountOf(_alice, 1_000, _currentIndex, false, false);
+        _wrappedMToken.setAccountOf(_bob, 500, _currentIndex, false, false);
 
         vm.expectEmit();
         emit IERC20.Transfer(_alice, _bob, 500);
@@ -1126,7 +1126,7 @@ contract WrappedMTokenTests is Test {
         _wrappedMToken.setPrincipalOfTotalEarningSupply(909);
         _wrappedMToken.setTotalEarningSupply(1_000);
 
-        _wrappedMToken.setAccountOf(_alice, 1_000, _currentIndex, false);
+        _wrappedMToken.setAccountOf(_alice, 1_000, _currentIndex, false, false);
 
         _mToken.setCurrentIndex((_currentIndex * 5) / 3); // 1_833333447838
 
@@ -1165,7 +1165,7 @@ contract WrappedMTokenTests is Test {
         aliceBalance_ = uint240(bound(aliceBalance_, 0, _getMaxAmount(aliceIndex_) / 4));
 
         if (aliceEarning_) {
-            _wrappedMToken.setAccountOf(_alice, aliceBalance_, aliceIndex_, false);
+            _wrappedMToken.setAccountOf(_alice, aliceBalance_, aliceIndex_, false, false);
             _wrappedMToken.setTotalEarningSupply(aliceBalance_);
 
             _wrappedMToken.setPrincipalOfTotalEarningSupply(
@@ -1180,7 +1180,7 @@ contract WrappedMTokenTests is Test {
         bobBalance_ = uint240(bound(bobBalance_, 0, _getMaxAmount(bobIndex_) / 4));
 
         if (bobEarning_) {
-            _wrappedMToken.setAccountOf(_bob, bobBalance_, bobIndex_, false);
+            _wrappedMToken.setAccountOf(_bob, bobBalance_, bobIndex_, false, false);
             _wrappedMToken.setTotalEarningSupply(_wrappedMToken.totalEarningSupply() + bobBalance_);
 
             _wrappedMToken.setPrincipalOfTotalEarningSupply(
@@ -1389,7 +1389,7 @@ contract WrappedMTokenTests is Test {
         _wrappedMToken.setPrincipalOfTotalEarningSupply(909);
         _wrappedMToken.setTotalEarningSupply(1_000);
 
-        _wrappedMToken.setAccountOf(_alice, 999, _currentIndex, false);
+        _wrappedMToken.setAccountOf(_alice, 999, _currentIndex, false, false);
 
         vm.expectEmit();
         emit IWrappedMToken.StoppedEarning(_alice);
@@ -1414,7 +1414,7 @@ contract WrappedMTokenTests is Test {
 
         _wrappedMToken.setTotalEarningSupply(balance_);
 
-        _wrappedMToken.setAccountOf(_alice, balance_, accountIndex_, false);
+        _wrappedMToken.setAccountOf(_alice, balance_, accountIndex_, false, false);
 
         _mToken.setCurrentIndex(index_);
 
@@ -1430,6 +1430,38 @@ contract WrappedMTokenTests is Test {
 
         assertEq(_wrappedMToken.totalNonEarningSupply(), balance_ + accruedYield_);
         assertEq(_wrappedMToken.totalEarningSupply(), 0);
+    }
+
+    /* ============ setClaimRecipient ============ */
+    function test_setClaimRecipient() external {
+        (, , , , bool hasClaimRecipient_) = _wrappedMToken.getAccountOf(_alice);
+
+        assertFalse(hasClaimRecipient_);
+        assertEq(_wrappedMToken.getInternalClaimRecipientOf(_alice), address(0));
+
+        vm.prank(_alice);
+        _wrappedMToken.setClaimRecipient(_alice);
+
+        (, , , , hasClaimRecipient_) = _wrappedMToken.getAccountOf(_alice);
+
+        assertTrue(hasClaimRecipient_);
+        assertEq(_wrappedMToken.getInternalClaimRecipientOf(_alice), _alice);
+
+        vm.prank(_alice);
+        _wrappedMToken.setClaimRecipient(_bob);
+
+        (, , , , hasClaimRecipient_) = _wrappedMToken.getAccountOf(_alice);
+
+        assertTrue(hasClaimRecipient_);
+        assertEq(_wrappedMToken.getInternalClaimRecipientOf(_alice), _bob);
+
+        vm.prank(_alice);
+        _wrappedMToken.setClaimRecipient(address(0));
+
+        (, , , , hasClaimRecipient_) = _wrappedMToken.getAccountOf(_alice);
+
+        assertFalse(hasClaimRecipient_);
+        assertEq(_wrappedMToken.getInternalClaimRecipientOf(_alice), address(0));
     }
 
     /* ============ stopEarningFor batch ============ */
@@ -1449,8 +1481,8 @@ contract WrappedMTokenTests is Test {
 
         _wrappedMToken.enableEarning();
 
-        _wrappedMToken.setAccountOf(_alice, 0, _currentIndex, false);
-        _wrappedMToken.setAccountOf(_bob, 0, _currentIndex, false);
+        _wrappedMToken.setAccountOf(_alice, 0, _currentIndex, false, false);
+        _wrappedMToken.setAccountOf(_bob, 0, _currentIndex, false, false);
 
         address[] memory accounts_ = new address[](2);
         accounts_[0] = _alice;
@@ -1548,7 +1580,7 @@ contract WrappedMTokenTests is Test {
 
         _wrappedMToken.enableEarning();
 
-        _wrappedMToken.setAccountOf(_alice, 500, _EXP_SCALED_ONE, false);
+        _wrappedMToken.setAccountOf(_alice, 500, _EXP_SCALED_ONE, false, false);
 
         assertEq(_wrappedMToken.balanceOf(_alice), 500);
 
@@ -1561,16 +1593,39 @@ contract WrappedMTokenTests is Test {
         assertEq(_wrappedMToken.balanceOf(_alice), 1_000);
     }
 
-    /* ============ claimOverrideRecipientFor ============ */
-    function test_claimOverrideRecipientFor() external {
-        assertEq(_wrappedMToken.claimOverrideRecipientFor(_alice), address(0));
+    /* ============ claimRecipientFor ============ */
+    function test_claimRecipientFor_hasClaimRecipient() external {
+        assertEq(_wrappedMToken.claimRecipientFor(_alice), address(0));
+
+        _wrappedMToken.setAccountOf(_alice, 0, 0, false, true);
+        _wrappedMToken.setInternalClaimRecipient(_alice, _bob);
+
+        assertEq(_wrappedMToken.claimRecipientFor(_alice), _bob);
+    }
+
+    function test_claimRecipientFor_hasClaimOverrideRecipient() external {
+        assertEq(_wrappedMToken.claimRecipientFor(_alice), address(0));
 
         _registrar.set(
             keccak256(abi.encode(_CLAIM_OVERRIDE_RECIPIENT_KEY_PREFIX, _alice)),
-            bytes32(uint256(uint160(_bob)))
+            bytes32(uint256(uint160(_charlie)))
         );
 
-        assertEq(_wrappedMToken.claimOverrideRecipientFor(_alice), _bob);
+        assertEq(_wrappedMToken.claimRecipientFor(_alice), _charlie);
+    }
+
+    function test_claimRecipientFor_hasClaimRecipientAndOverrideRecipient() external {
+        assertEq(_wrappedMToken.claimRecipientFor(_alice), address(0));
+
+        _wrappedMToken.setAccountOf(_alice, 0, 0, false, true);
+        _wrappedMToken.setInternalClaimRecipient(_alice, _bob);
+
+        _registrar.set(
+            keccak256(abi.encode(_CLAIM_OVERRIDE_RECIPIENT_KEY_PREFIX, _alice)),
+            bytes32(uint256(uint160(_charlie)))
+        );
+
+        assertEq(_wrappedMToken.claimRecipientFor(_alice), _bob);
     }
 
     /* ============ totalSupply ============ */

--- a/test/utils/WrappedMTokenHarness.sol
+++ b/test/utils/WrappedMTokenHarness.sol
@@ -33,12 +33,22 @@ contract WrappedMTokenHarness is WrappedMToken {
         _accounts[account_].lastIndex = uint128(index_);
     }
 
-    function setAccountOf(address account_, uint256 balance_, uint256 index_, bool hasEarnerDetails_) external {
-        _accounts[account_] = Account(true, uint240(balance_), uint128(index_), hasEarnerDetails_);
+    function setAccountOf(
+        address account_,
+        uint256 balance_,
+        uint256 index_,
+        bool hasEarnerDetails_,
+        bool hasClaimRecipient_
+    ) external {
+        _accounts[account_] = Account(true, uint240(balance_), uint128(index_), hasEarnerDetails_, hasClaimRecipient_);
     }
 
     function setAccountOf(address account_, uint256 balance_) external {
-        _accounts[account_] = Account(false, uint240(balance_), 0, false);
+        _accounts[account_] = Account(false, uint240(balance_), 0, false, false);
+    }
+
+    function setInternalClaimRecipient(address account_, address claimRecipient_) external {
+        _claimRecipients[account_] = claimRecipient_;
     }
 
     function setTotalNonEarningSupply(uint256 totalNonEarningSupply_) external {
@@ -53,8 +63,24 @@ contract WrappedMTokenHarness is WrappedMToken {
         principalOfTotalEarningSupply = uint112(principalOfTotalEarningSupply_);
     }
 
-    function getAccountOf(address account_) external view returns (bool isEarning_, uint240 balance_, uint128 index_) {
+    function getAccountOf(
+        address account_
+    )
+        external
+        view
+        returns (bool isEarning_, uint240 balance_, uint128 index_, bool hasEarnerDetails_, bool hasClaimRecipient_)
+    {
         Account storage account = _accounts[account_];
-        return (account.isEarning, account.balance, account.lastIndex);
+        return (
+            account.isEarning,
+            account.balance,
+            account.lastIndex,
+            account.hasEarnerDetails,
+            account.hasClaimRecipient
+        );
+    }
+
+    function getInternalClaimRecipientOf(address account_) external view returns (address claimRecipient_) {
+        return _claimRecipients[account_];
     }
 }


### PR DESCRIPTION
- claim recipient by default is the account itself
- registrar can override the claim recipient
- the account can explicitly sets a claim recipient, which take precedence over what the Registrar defines